### PR TITLE
Ignore .exe files for the builds under cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*.swp
 *.o
+*.exe
 *.bin
 *.vec
 data


### PR DESCRIPTION
GCC or G++ under Cygwin will automatically suffixes the output executable with ".exe". So the output binary for this project is "fasttext.exe", which is not ignored by git. This fixes all executable suffexed by ".exe" to be ignored.